### PR TITLE
Fix NPE in ClientMain

### DIFF
--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -55,7 +55,14 @@ final class ClientMain {
     try (final BufferedReader input = new BufferedReader(new InputStreamReader(System.in))) {
       while (keepRunning) {
         System.out.print(">>> ");
-        keepRunning = chat.handleCommand(input.readLine().trim());
+        if (input == null) {
+          break;
+        }
+        String untrimmedLine = input.readLine();
+        if (untrimmedLine == null) {
+          break;
+        }
+        keepRunning = chat.handleCommand(untrimmedLine.trim());
       }
     } catch (IOException ex) {
       LOG.error("Failed to read from input");


### PR DESCRIPTION
Before this change, if I typed control-D ("end of input") in the chat client, it would die with a NullPointerException on line 58 of ClientMain.java.

With this change, typing control-D causes the chat client to exit gracefully.